### PR TITLE
solve issue of low contrast

### DIFF
--- a/res/layout/activity_main.xml
+++ b/res/layout/activity_main.xml
@@ -108,6 +108,7 @@
 
     <TextView
         android:id="@+id/main_first_run"
+        android:textColor="#707070"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingLeft="@dimen/default_spacing"


### PR DESCRIPTION
The original text color of the component is '#808080', and the contrast between the text color ('#808080') and the background color ('#F5F5F5') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#707070') are as follows:
![image](https://user-images.githubusercontent.com/101503193/167408975-4e3c2525-0229-4816-bf9b-7d63f9d3eb19.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.